### PR TITLE
Force Dutch captions in "What is Bitcoin" video

### DIFF
--- a/nl/index.html
+++ b/nl/index.html
@@ -30,7 +30,7 @@ title: Wat is Bitcoin? - We Use Coins
   </div>
 </div>
 <div id="whatisbitcoin" class="box videobox">
-  <iframe id="ytplayer" type="text/html" width="640" height="390" src="//www.youtube.com/embed/Um63OQz3bjo?fs=1&amp;hl=en_US&amp;rel=0&amp;hd=1&amp;origin=http://www.weusecoins.com" frameborder="0" allowfullscreen></iframe>
+  <iframe id="ytplayer" type="text/html" width="640" height="390" src="//www.youtube.com/embed/Um63OQz3bjo?fs=1&amp;hl=nl&amp;rel=0&amp;hd=1&amp;cc_load_policy=1&amp;origin=http://www.weusecoins.com&amp;hl=nl_NL&amp;cc_load_policy=1" frameborder="0" allowfullscreen></iframe>
 </div>
 <div id="walletbanner"><span class="caption">Portefeuilles zijn gratis!</span><a class="fbtn small" href="aan-de-slag">Aan de slag &raquo;</a></div>
 <div class="merchantfeature"><img src="gx/board_merchant_minutes.gif"/><a class="fbtn tiny" href="voor-handelaars">Leer meer &raquo;</a></div>


### PR DESCRIPTION
I noticed we have Dutch captions on the "What is Bitcoin" video but no one will look for the switch caption button in the embedded YouTube video. This commit forces the Dutch captions to load on the Dutch version of the website. It only works in the Flash version though, forcing a language will always default to the English captions in the HTML5 version.
